### PR TITLE
feat: add member list and bio pages

### DIFF
--- a/app/(main)/apps/user-management/list/MemberDetail.tsx
+++ b/app/(main)/apps/user-management/list/MemberDetail.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import React from 'react';
+
+export interface Member {
+  id: number;
+  membership_id: string;
+  first_name: string;
+  last_name: string;
+  phone: string;
+  status: string;
+  join_date: string;
+  gender: string;
+  dob: string;
+  address: string;
+  occupation: string;
+  family_members: string;
+  emergency_name: string;
+  emergency_number: string;
+  email: string;
+  notes: string;
+  created_at: string;
+}
+
+const formatDate = (d: string) => (d ? new Date(d).toISOString().slice(0, 10) : '');
+
+/**
+ * Displays all details of a member in a simple grid.
+ */
+export default function MemberDetail({ member }: { member: Member }) {
+  return (
+    <div className="grid text-900">
+      <div className="col-12 md:col-6">
+        <strong>Membership ID:</strong> {member.membership_id}
+      </div>
+      <div className="col-12 md:col-6">
+        <strong>First Name:</strong> {member.first_name}
+      </div>
+      <div className="col-12 md:col-6">
+        <strong>Last Name:</strong> {member.last_name}
+      </div>
+      <div className="col-12 md:col-6">
+        <strong>Gender:</strong> {member.gender}
+      </div>
+      <div className="col-12 md:col-6">
+        <strong>DOB:</strong> {formatDate(member.dob)}
+      </div>
+      <div className="col-12 md:col-6">
+        <strong>Email:</strong> {member.email || '-'}
+      </div>
+      <div className="col-12 md:col-6">
+        <strong>Phone:</strong> {member.phone}
+      </div>
+      <div className="col-12">
+        <strong>Address:</strong> {member.address}
+      </div>
+      <div className="col-12 md:col-6">
+        <strong>Join Date:</strong> {formatDate(member.join_date)}
+      </div>
+      <div className="col-12 md:col-6">
+        <strong>Status:</strong> {member.status}
+      </div>
+      <div className="col-12 md:col-6">
+        <strong>Occupation:</strong> {member.occupation}
+      </div>
+      <div className="col-12 md:col-6">
+        <strong>Family Members:</strong> {member.family_members}
+      </div>
+      <div className="col-12 md:col-6">
+        <strong>Emergency Name:</strong> {member.emergency_name || '-'}
+      </div>
+      <div className="col-12 md:col-6">
+        <strong>Emergency Number:</strong> {member.emergency_number || '-'}
+      </div>
+      <div className="col-12">
+        <strong>Notes:</strong> {member.notes || '-'}
+      </div>
+      <div className="col-12 md:col-6">
+        <strong>Created At:</strong> {formatDate(member.created_at)}
+      </div>
+    </div>
+  );
+}
+

--- a/app/(main)/apps/user-management/profile/[id]/page.tsx
+++ b/app/(main)/apps/user-management/profile/[id]/page.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from 'primereact/button';
+import MemberDetail, { Member } from '../../list/MemberDetail';
+
+const API_BASE =
+  process.env.NEXT_PUBLIC_API_BASE_URL?.replace(/\/$/, '') || 'http://127.0.0.1:8000';
+
+export default function MemberBioPage({ params }: { params: { id: string } }) {
+  const router = useRouter();
+  const [member, setMember] = useState<Member | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchMember = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`${API_BASE}/api/members/${params.id}/`);
+      if (!res.ok) throw new Error('Failed to fetch member');
+      const data: Member = await res.json();
+      setMember(data);
+    } catch (err: any) {
+      setError(err.message || 'Failed to fetch member');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchMember();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [params.id]);
+
+  if (loading) {
+    return <div className="card p-4">Loading...</div>;
+  }
+
+  if (error) {
+    return (
+      <div className="card p-4 text-center">
+        <p className="mb-3">Error loading member.</p>
+        <Button label="Retry" icon="pi pi-refresh" onClick={fetchMember} />
+      </div>
+    );
+  }
+
+  if (!member) {
+    return null;
+  }
+
+  return (
+    <div className="card">
+      <div className="flex justify-content-between align-items-center mb-4">
+        <Button
+          label="Back"
+          icon="pi pi-arrow-left"
+          onClick={() => router.push('/apps/user-management/list')}
+          aria-label="Back to list"
+        />
+        <h2 className="m-0 text-xl">Member Bio</h2>
+      </div>
+      <h3 className="text-2xl mb-4">
+        {member.first_name} {member.last_name}
+      </h3>
+      <MemberDetail member={member} />
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add reusable `MemberDetail` component for displaying full member information
- replace demo list with member table fetching from backend and showing modal details
- create dynamic bio page for each member

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3694289808330bdbd5428c992eccf