### PR TITLE
feat: add member list and bio pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
-<<<<<<< Updated upstream
-# es-front
-front end of esamithi
-=======
+# Next.js Testing
+
 This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
 
 ## Getting Started
@@ -24,6 +22,5 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 To learn more about Next.js, take a look at the following resources:
 
--   [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
--   [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
->>>>>>> Stashed changes
+- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
+- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.

--- a/app/(main)/apps/user-management/MemberDetail.tsx
+++ b/app/(main)/apps/user-management/MemberDetail.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import React from 'react';
+
+export interface Member {
+  id: number;
+  membership_id: string;
+  first_name: string;
+  last_name: string;
+  nic: string;
+  phone: string;
+  status: string;
+  join_date: string;
+  gender: string;
+  dob: string;
+  address: string;
+  occupation: string;
+  family_members: string;
+  emergency_name: string;
+  emergency_number: string;
+  email: string;
+  notes: string;
+}
+
+const formatDate = (d: string) => (d ? new Date(d).toISOString().slice(0, 10) : '-');
+
+export default function MemberDetail({ member }: { member: Member }) {
+  return (
+    <div className="grid">
+      <div className="col-12 md:col-6">
+        <strong>Membership ID:</strong> {member.membership_id}
+      </div>
+      <div className="col-12 md:col-6">
+        <strong>First Name:</strong> {member.first_name}
+      </div>
+      <div className="col-12 md:col-6">
+        <strong>Last Name:</strong> {member.last_name}
+      </div>
+      <div className="col-12 md:col-6">
+        <strong>NIC:</strong> {member.nic}
+      </div>
+      <div className="col-12 md:col-6">
+        <strong>Phone:</strong> {member.phone}
+      </div>
+      <div className="col-12 md:col-6">
+        <strong>Email:</strong> {member.email || '-'}
+      </div>
+      <div className="col-12">
+        <strong>Address:</strong> {member.address}
+      </div>
+      <div className="col-12 md:col-6">
+        <strong>Join Date:</strong> {formatDate(member.join_date)}
+      </div>
+      <div className="col-12 md:col-6">
+        <strong>Status:</strong> {member.status}
+      </div>
+      <div className="col-12 md:col-6">
+        <strong>Occupation:</strong> {member.occupation}
+      </div>
+      <div className="col-12 md:col-6">
+        <strong>Gender:</strong> {member.gender}
+      </div>
+      <div className="col-12 md:col-6">
+        <strong>DOB:</strong> {formatDate(member.dob)}
+      </div>
+      <div className="col-12">
+        <strong>Family Members:</strong> {member.family_members}
+      </div>
+      <div className="col-12 md:col-6">
+        <strong>Emergency Name:</strong> {member.emergency_name}
+      </div>
+      <div className="col-12 md:col-6">
+        <strong>Emergency Number:</strong> {member.emergency_number}
+      </div>
+      <div className="col-12">
+        <strong>Notes:</strong> {member.notes || '-'}
+      </div>
+    </div>
+  );
+}
+

--- a/app/(main)/apps/user-management/list/page.tsx
+++ b/app/(main)/apps/user-management/list/page.tsx
@@ -6,23 +6,17 @@ import { DataTable } from 'primereact/datatable';
 import { Column } from 'primereact/column';
 import { Button } from 'primereact/button';
 import { ProgressSpinner } from 'primereact/progressspinner';
+import { Dialog } from 'primereact/dialog';
+import MemberDetail, { Member } from '../MemberDetail';
 
 const API_BASE =
   process.env.NEXT_PUBLIC_API_BASE_URL?.replace(/\/$/, '') || 'http://127.0.0.1:8000';
 
-interface Member {
-  id: number;
-  membership_id: string;
-  first_name: string;
-  last_name: string;
-  phone: string;
-  status: string;
-  join_date: string;
-}
-
 export default function MemberListPage() {
   const router = useRouter();
   const [members, setMembers] = useState<Member[]>([]);
+  const [selected, setSelected] = useState<Member | null>(null);
+  const [display, setDisplay] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -46,15 +40,28 @@ export default function MemberListPage() {
   }, []);
 
   const formatDate = (d: string) => (d ? new Date(d).toISOString().slice(0, 10) : '');
+  const viewMember = (member: Member) => {
+    setSelected(member);
+    setDisplay(true);
+  };
 
   const actionBodyTemplate = (member: Member) => (
-    <Button
-      label="Bio"
-      icon="pi pi-user"
-      className="p-button-text"
-      onClick={() => router.push(`/apps/user-management/profile/${member.id}`)}
-      aria-label={`Open bio for ${member.first_name} ${member.last_name}`}
-    />
+    <div className="flex gap-1">
+      <Button
+        label="View"
+        icon="pi pi-eye"
+        className="p-button-text"
+        onClick={() => viewMember(member)}
+        aria-label={`View member ${member.first_name} ${member.last_name}`}
+      />
+      <Button
+        label="Bio"
+        icon="pi pi-user"
+        className="p-button-text"
+        onClick={() => router.push(`/apps/user-management/profile/${member.id}`)}
+        aria-label={`Open bio for ${member.first_name} ${member.last_name}`}
+      />
+    </div>
   );
 
   const membershipBodyTemplate = (member: Member) => (
@@ -115,6 +122,15 @@ export default function MemberListPage() {
           />
         </DataTable>
       )}
+      <Dialog
+        header={`Member: ${selected?.membership_id} — ${selected?.first_name} ${selected?.last_name}`}
+        visible={display}
+        style={{ width: '50vw' }}
+        breakpoints={{ '960px': '75vw', '641px': '90vw' }}
+        onHide={() => setDisplay(false)}
+      >
+        {selected && <MemberDetail member={selected} />}
+      </Dialog>
     </div>
   );
 }

--- a/app/(main)/apps/user-management/list/page.tsx
+++ b/app/(main)/apps/user-management/list/page.tsx
@@ -1,148 +1,121 @@
 'use client';
+
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { FilterMatchMode, FilterOperator } from 'primereact/api';
-import { Button } from 'primereact/button';
+import { DataTable } from 'primereact/datatable';
 import { Column } from 'primereact/column';
-import { DataTable, DataTableFilterMeta } from 'primereact/datatable';
-import { InputText } from 'primereact/inputtext';
-import { ProgressBar } from 'primereact/progressbar';
-import React, { useEffect, useRef, useState } from 'react';
-import { CustomerService } from '../../../../../demo/service/CustomerService';
+import { Button } from 'primereact/button';
+import { ProgressSpinner } from 'primereact/progressspinner';
 
-function List() {
-    const [customers, setCustomers] = useState<Demo.Customer[]>([]);
-    const [filters, setFilters] = useState<DataTableFilterMeta>({});
-    const [loading, setLoading] = useState(true);
-    const [globalFilterValue, setGlobalFilterValue] = useState('');
-    const router = useRouter();
-    const dt = useRef(null);
+const API_BASE =
+  process.env.NEXT_PUBLIC_API_BASE_URL?.replace(/\/$/, '') || 'http://127.0.0.1:8000';
 
-    const getCustomers = (data: Demo.Customer[]) => {
-        return [...(data || [])].map((d) => {
-            d.date = new Date(d.date);
-            return d;
-        });
-    };
-
-    const formatDate = (value: Date) => {
-        return value.toLocaleDateString('en-US', {
-            day: '2-digit',
-            month: '2-digit',
-            year: 'numeric'
-        });
-    };
-    const clearFilter = () => {
-        initFilters();
-    };
-
-    const initFilters = () => {
-        setFilters({
-            global: { value: null, matchMode: FilterMatchMode.CONTAINS },
-            name: {
-                operator: FilterOperator.AND,
-                constraints: [{ value: null, matchMode: FilterMatchMode.STARTS_WITH }]
-            },
-            'country.name': {
-                operator: FilterOperator.AND,
-                constraints: [{ value: null, matchMode: FilterMatchMode.STARTS_WITH }]
-            },
-            representative: { value: null, matchMode: FilterMatchMode.IN },
-            date: {
-                operator: FilterOperator.AND,
-                constraints: [{ value: null, matchMode: FilterMatchMode.DATE_IS }]
-            },
-            activity: { value: null, matchMode: FilterMatchMode.BETWEEN }
-        });
-        setGlobalFilterValue('');
-    };
-
-    useEffect(() => {
-        CustomerService.getCustomersLarge().then((data) => {
-            setCustomers(getCustomers(data));
-            setLoading(false);
-        });
-        initFilters();
-    }, []);
-
-    const onGlobalFilterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        const { value } = e.target;
-        let _filters = { ...filters };
-        (_filters['global'] as any).value = value;
-        setFilters(_filters);
-        setGlobalFilterValue(value);
-    };
-
-    const renderHeader = () => {
-        return (
-            <div className="flex flex-wrap gap-2 align-items-center justify-content-between">
-                <span className="p-input-icon-left w-full sm:w-20rem flex-order-1 sm:flex-order-0">
-                    <i className="pi pi-search"></i>
-                    <InputText value={globalFilterValue} onChange={onGlobalFilterChange} placeholder="Global Search" className="w-full" />
-                </span>
-                <Button type="button" icon="pi pi-user-plus" label="Add New" className="w-full sm:w-auto flex-order-0 sm:flex-order-1" outlined onClick={() => router.push('/apps/user-management/create')} />
-            </div>
-        );
-    };
-
-    const nameBodyTemplate = (customer: Demo.Customer) => {
-        return (
-            <>
-                <span className="p-column-title">Name</span>
-                {customer.name}
-            </>
-        );
-    };
-
-    const countryBodyTemplate = (customer: Demo.Customer) => {
-        return (
-            <>
-                <img alt={customer.country.name} src={`/demo/images/flag/flag_placeholder.png`} className={'w-2rem mr-2 flag flag-' + customer.country.code} />
-                <span className="image-text">{customer.country.name}</span>
-            </>
-        );
-    };
-
-    const createdByBodyTemplate = (customer: Demo.Customer) => {
-        return (
-            <div className="inline-flex align-items-center">
-                <img alt={customer.representative.name} src={`/demo/images/avatar/${customer.representative.image}`} className="w-2rem mr-2" />
-                <span>{customer.representative.name}</span>
-            </div>
-        );
-    };
-
-    const dateBodyTemplate = (customer: Demo.Customer) => {
-        return formatDate(customer.date);
-    };
-
-    const activityBodyTemplate = (customer: Demo.Customer) => {
-        return <ProgressBar value={customer.activity} showValue={false} style={{ height: '.5rem' }} />;
-    };
-
-    const header = renderHeader();
-
-    return (
-        <div className="card">
-            <DataTable
-                ref={dt}
-                value={customers}
-                header={header}
-                paginator
-                rows={10}
-                responsiveLayout="scroll"
-                currentPageReportTemplate="Showing {first} to {last} of {totalRecords} entries"
-                rowsPerPageOptions={[10, 25, 50]}
-                filters={filters}
-                loading={loading}
-            >
-                <Column field="name" header="Name" sortable body={nameBodyTemplate} headerClassName="white-space-nowrap" style={{ width: '25%' }}></Column>
-                <Column field="country.name" header="Country" sortable body={countryBodyTemplate} headerClassName="white-space-nowrap" style={{ width: '25%' }}></Column>
-                <Column field="date" header="Join Date" sortable body={dateBodyTemplate} headerClassName="white-space-nowrap" style={{ width: '25%' }}></Column>
-                <Column field="representative.name" header="Created By" body={createdByBodyTemplate} headerClassName="white-space-nowrap" style={{ width: '25%' }} sortable></Column>
-                <Column field="activity" header="Activity" body={activityBodyTemplate} headerClassName="white-space-nowrap" style={{ width: '25%' }} sortable></Column>
-            </DataTable>
-        </div>
-    );
+interface Member {
+  id: number;
+  membership_id: string;
+  first_name: string;
+  last_name: string;
+  phone: string;
+  status: string;
+  join_date: string;
 }
 
-export default List;
+export default function MemberListPage() {
+  const router = useRouter();
+  const [members, setMembers] = useState<Member[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchMembers = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`${API_BASE}/api/members/`);
+      if (!res.ok) throw new Error('Failed to fetch members');
+      const data: Member[] = await res.json();
+      setMembers(data);
+    } catch (err: any) {
+      setError(err.message || 'Error fetching members');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchMembers();
+  }, []);
+
+  const formatDate = (d: string) => (d ? new Date(d).toISOString().slice(0, 10) : '');
+
+  const actionBodyTemplate = (member: Member) => (
+    <Button
+      label="Bio"
+      icon="pi pi-user"
+      className="p-button-text"
+      onClick={() => router.push(`/apps/user-management/profile/${member.id}`)}
+      aria-label={`Open bio for ${member.first_name} ${member.last_name}`}
+    />
+  );
+
+  const membershipBodyTemplate = (member: Member) => (
+    <Button
+      label={member.membership_id}
+      className="p-button-link p-0"
+      onClick={() => router.push(`/apps/user-management/profile/${member.id}`)}
+      aria-label={`Open bio for ${member.first_name} ${member.last_name}`}
+    />
+  );
+
+  return (
+    <div className="card">
+      <div className="flex justify-content-between align-items-center mb-3">
+        <h2 className="m-0 text-xl">Members</h2>
+        <Button
+          label="Create Member"
+          icon="pi pi-plus"
+          onClick={() => router.push('/apps/user-management/create')}
+          aria-label="Create member"
+        />
+      </div>
+
+      {loading && (
+        <div className="flex justify-content-center p-4">
+          <ProgressSpinner />
+        </div>
+      )}
+
+      {!loading && error && (
+        <div className="p-4 text-center">
+          <p className="mb-3">Error loading members.</p>
+          <Button label="Retry" icon="pi pi-refresh" onClick={fetchMembers} />
+        </div>
+      )}
+
+      {!loading && !error && (
+        <DataTable value={members} responsiveLayout="scroll" emptyMessage="No members found.">
+          <Column
+            field="membership_id"
+            header="Membership ID"
+            body={membershipBodyTemplate}
+            style={{ minWidth: '12rem' }}
+          />
+          <Column field="first_name" header="First Name" />
+          <Column field="last_name" header="Last Name" />
+          <Column field="phone" header="Phone" />
+          <Column field="status" header="Status" />
+          <Column
+            field="join_date"
+            header="Join Date"
+            body={(m: Member) => formatDate(m.join_date)}
+          />
+          <Column
+            header="Actions"
+            body={actionBodyTemplate}
+            style={{ minWidth: '6rem' }}
+          />
+        </DataTable>
+      )}
+    </div>
+  );
+}
+

--- a/app/(main)/apps/user-management/profile/[id]/page.tsx
+++ b/app/(main)/apps/user-management/profile/[id]/page.tsx
@@ -11,29 +11,10 @@ import { Card } from 'primereact/card';
 import { Toast } from 'primereact/toast';
 import { ProgressSpinner } from 'primereact/progressspinner';
 import { ConfirmDialog, confirmDialog } from 'primereact/confirmdialog';
+import MemberDetail, { Member } from '../../MemberDetail';
 
 const API_BASE =
   process.env.NEXT_PUBLIC_API_BASE_URL?.replace(/\/$/, '') || 'http://127.0.0.1:8000';
-
-interface Member {
-  id: number;
-  membership_id: string;
-  first_name: string;
-  last_name: string;
-  nic: string;
-  phone: string;
-  status: string;
-  join_date: string;
-  gender: string;
-  dob: string;
-  address: string;
-  occupation: string;
-  family_members: string;
-  emergency_name: string;
-  emergency_number: string;
-  email: string;
-  notes: string;
-}
 
 export default function MemberBioPage({ params }: { params: { id: string } }) {
   const router = useRouter();
@@ -150,7 +131,6 @@ export default function MemberBioPage({ params }: { params: { id: string } }) {
     }
   };
 
-  const formatDate = (d: string) => (d ? new Date(d).toISOString().slice(0, 10) : '');
 
   if (loading) {
     return (
@@ -374,56 +354,7 @@ export default function MemberBioPage({ params }: { params: { id: string } }) {
             </div>
           </div>
         ) : (
-          <div className="grid">
-            <div className="col-12 md:col-6">
-              <strong>Membership ID:</strong> {member.membership_id}
-            </div>
-            <div className="col-12 md:col-6">
-              <strong>First Name:</strong> {member.first_name}
-            </div>
-            <div className="col-12 md:col-6">
-              <strong>Last Name:</strong> {member.last_name}
-            </div>
-            <div className="col-12 md:col-6">
-              <strong>NIC:</strong> {member.nic}
-            </div>
-            <div className="col-12 md:col-6">
-              <strong>Phone:</strong> {member.phone}
-            </div>
-            <div className="col-12 md:col-6">
-              <strong>Email:</strong> {member.email || '-'}
-            </div>
-            <div className="col-12">
-              <strong>Address:</strong> {member.address}
-            </div>
-            <div className="col-12 md:col-6">
-              <strong>Join Date:</strong> {formatDate(member.join_date)}
-            </div>
-            <div className="col-12 md:col-6">
-              <strong>Status:</strong> {member.status}
-            </div>
-            <div className="col-12 md:col-6">
-              <strong>Occupation:</strong> {member.occupation}
-            </div>
-            <div className="col-12 md:col-6">
-              <strong>Gender:</strong> {member.gender}
-            </div>
-            <div className="col-12 md:col-6">
-              <strong>DOB:</strong> {formatDate(member.dob)}
-            </div>
-            <div className="col-12">
-              <strong>Family Members:</strong> {member.family_members}
-            </div>
-            <div className="col-12 md:col-6">
-              <strong>Emergency Name:</strong> {member.emergency_name}
-            </div>
-            <div className="col-12 md:col-6">
-              <strong>Emergency Number:</strong> {member.emergency_number}
-            </div>
-            <div className="col-12">
-              <strong>Notes:</strong> {member.notes || '-'}
-            </div>
-          </div>
+          <MemberDetail member={member} />
         )}
       </Card>
     </div>

--- a/app/(main)/apps/user-management/profile/[id]/page.tsx
+++ b/app/(main)/apps/user-management/profile/[id]/page.tsx
@@ -1,0 +1,432 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from 'primereact/button';
+import { InputText } from 'primereact/inputtext';
+import { InputTextarea } from 'primereact/inputtextarea';
+import { Dropdown } from 'primereact/dropdown';
+import { Calendar } from 'primereact/calendar';
+import { Card } from 'primereact/card';
+import { Toast } from 'primereact/toast';
+import { ProgressSpinner } from 'primereact/progressspinner';
+import { ConfirmDialog, confirmDialog } from 'primereact/confirmdialog';
+
+const API_BASE =
+  process.env.NEXT_PUBLIC_API_BASE_URL?.replace(/\/$/, '') || 'http://127.0.0.1:8000';
+
+interface Member {
+  id: number;
+  membership_id: string;
+  first_name: string;
+  last_name: string;
+  nic: string;
+  phone: string;
+  status: string;
+  join_date: string;
+  gender: string;
+  dob: string;
+  address: string;
+  occupation: string;
+  family_members: string;
+  emergency_name: string;
+  emergency_number: string;
+  email: string;
+  notes: string;
+}
+
+export default function MemberBioPage({ params }: { params: { id: string } }) {
+  const router = useRouter();
+  const toast = useRef<Toast>(null);
+  const [member, setMember] = useState<Member | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [edit, setEdit] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [form, setForm] = useState<Partial<Member>>({});
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const fetchMember = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`${API_BASE}/api/members/${params.id}/`);
+      if (!res.ok) throw new Error('Failed to fetch member');
+      const data: Member = await res.json();
+      setMember(data);
+      setForm(data);
+    } catch {
+      toast.current?.show({ severity: 'error', summary: 'Error', detail: 'Failed to load member' });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchMember();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [params.id]);
+
+  const handleChange = (field: keyof Member, value: any) => {
+    setForm({ ...form, [field]: value });
+  };
+
+  const onEdit = () => {
+    setEdit(true);
+    setForm(member || {});
+    setErrors({});
+  };
+
+  const onCancel = () => {
+    setEdit(false);
+    setForm(member || {});
+    setErrors({});
+  };
+
+  const save = async () => {
+    const required: (keyof Member)[] = [
+      'first_name',
+      'last_name',
+      'nic',
+      'phone',
+      'address',
+      'membership_id',
+      'join_date',
+      'occupation',
+      'status',
+    ];
+    const newErrors: Record<string, string> = {};
+    required.forEach((f) => {
+      if (!form[f]) newErrors[f] = 'Required';
+    });
+    if (Object.keys(newErrors).length) {
+      setErrors(newErrors);
+      return;
+    }
+    setSaving(true);
+    try {
+      const payload: Partial<Member> = {};
+      Object.keys(form).forEach((k) => {
+        if ((form as any)[k] !== (member as any)?.[k]) {
+          (payload as any)[k] = (form as any)[k];
+        }
+      });
+      const res = await fetch(`${API_BASE}/api/members/${params.id}/`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        setErrors(err);
+        throw new Error('Failed to save');
+      }
+      const updated: Member = await res.json();
+      setMember(updated);
+      setEdit(false);
+      toast.current?.show({ severity: 'success', summary: 'Saved', detail: 'Member updated' });
+    } catch {
+      toast.current?.show({ severity: 'error', summary: 'Error', detail: 'Could not save member' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const confirmDelete = () => {
+    confirmDialog({
+      message: `Are you sure you want to delete member ${member?.membership_id} — ${member?.first_name} ${member?.last_name}? This action cannot be undone.`,
+      header: 'Delete Member',
+      icon: 'pi pi-exclamation-triangle',
+      accept: delMember,
+    });
+  };
+
+  const delMember = async () => {
+    try {
+      const res = await fetch(`${API_BASE}/api/members/${params.id}/`, { method: 'DELETE' });
+      if (!res.ok) throw new Error('Delete failed');
+      toast.current?.show({ severity: 'success', summary: 'Deleted', detail: 'Member removed' });
+      router.push('/apps/user-management/list');
+    } catch {
+      toast.current?.show({ severity: 'error', summary: 'Error', detail: 'Could not delete member' });
+    }
+  };
+
+  const formatDate = (d: string) => (d ? new Date(d).toISOString().slice(0, 10) : '');
+
+  if (loading) {
+    return (
+      <div className="card flex justify-content-center p-6">
+        <ProgressSpinner />
+      </div>
+    );
+  }
+
+  if (!member) return null;
+
+  return (
+    <div className="card">
+      <Toast ref={toast} />
+      <ConfirmDialog />
+      <div className="flex justify-content-between align-items-center mb-4">
+        <Button
+          label="Back"
+          icon="pi pi-arrow-left"
+          className="p-button-text"
+          onClick={() => router.push('/apps/user-management/list')}
+          aria-label="Back to list"
+        />
+        <h2 className="m-0">
+          {member.first_name} {member.last_name}
+        </h2>
+        <div className="flex gap-2">
+          {!edit && (
+            <>
+              <Button
+                label="Edit"
+                icon="pi pi-pencil"
+                onClick={onEdit}
+                aria-label="Edit member"
+              />
+              <Button
+                label="Delete"
+                icon="pi pi-trash"
+                className="p-button-danger"
+                onClick={confirmDelete}
+                aria-label="Delete member"
+              />
+            </>
+          )}
+        </div>
+      </div>
+      <Card>
+        {edit ? (
+          <div className="formgrid grid p-fluid">
+            <div className="field col-12 md:col-6">
+              <label htmlFor="membership_id">Membership ID</label>
+              <InputText
+                id="membership_id"
+                value={form.membership_id || ''}
+                onChange={(e) => handleChange('membership_id', e.target.value)}
+              />
+              {errors.membership_id && <small className="p-error">{errors.membership_id}</small>}
+            </div>
+            <div className="field col-12 md:col-6">
+              <label htmlFor="first_name">First Name</label>
+              <InputText
+                id="first_name"
+                value={form.first_name || ''}
+                onChange={(e) => handleChange('first_name', e.target.value)}
+              />
+              {errors.first_name && <small className="p-error">{errors.first_name}</small>}
+            </div>
+            <div className="field col-12 md:col-6">
+              <label htmlFor="last_name">Last Name</label>
+              <InputText
+                id="last_name"
+                value={form.last_name || ''}
+                onChange={(e) => handleChange('last_name', e.target.value)}
+              />
+              {errors.last_name && <small className="p-error">{errors.last_name}</small>}
+            </div>
+            <div className="field col-12 md:col-6">
+              <label htmlFor="nic">NIC</label>
+              <InputText
+                id="nic"
+                value={form.nic || ''}
+                onChange={(e) => handleChange('nic', e.target.value)}
+              />
+              {errors.nic && <small className="p-error">{errors.nic}</small>}
+            </div>
+            <div className="field col-12 md:col-6">
+              <label htmlFor="phone">Phone</label>
+              <InputText
+                id="phone"
+                value={form.phone || ''}
+                onChange={(e) => handleChange('phone', e.target.value)}
+              />
+              {errors.phone && <small className="p-error">{errors.phone}</small>}
+            </div>
+            <div className="field col-12 md:col-6">
+              <label htmlFor="email">Email</label>
+              <InputText
+                id="email"
+                value={form.email || ''}
+                onChange={(e) => handleChange('email', e.target.value)}
+              />
+            </div>
+            <div className="field col-12">
+              <label htmlFor="address">Address</label>
+              <InputTextarea
+                id="address"
+                rows={3}
+                value={form.address || ''}
+                onChange={(e) => handleChange('address', e.target.value)}
+              />
+              {errors.address && <small className="p-error">{errors.address}</small>}
+            </div>
+            <div className="field col-12 md:col-6">
+              <label htmlFor="occupation">Occupation</label>
+              <InputText
+                id="occupation"
+                value={form.occupation || ''}
+                onChange={(e) => handleChange('occupation', e.target.value)}
+              />
+              {errors.occupation && <small className="p-error">{errors.occupation}</small>}
+            </div>
+            <div className="field col-12 md:col-6">
+              <label htmlFor="status">Status</label>
+              <Dropdown
+                id="status"
+                options={['Active', 'Inactive']}
+                value={form.status || ''}
+                onChange={(e) => handleChange('status', e.value)}
+                placeholder="Select"
+              />
+              {errors.status && <small className="p-error">{errors.status}</small>}
+            </div>
+            <div className="field col-12 md:col-6">
+              <label htmlFor="gender">Gender</label>
+              <InputText
+                id="gender"
+                value={form.gender || ''}
+                onChange={(e) => handleChange('gender', e.target.value)}
+              />
+            </div>
+            <div className="field col-12 md:col-6">
+              <label htmlFor="join_date">Join Date</label>
+              <Calendar
+                id="join_date"
+                value={form.join_date ? new Date(form.join_date) : undefined}
+                onChange={(e) =>
+                  handleChange(
+                    'join_date',
+                    (e.value as Date | null)?.toISOString().slice(0, 10) || ''
+                  )
+                }
+                dateFormat="yy-mm-dd"
+                showIcon
+              />
+              {errors.join_date && <small className="p-error">{errors.join_date}</small>}
+            </div>
+            <div className="field col-12 md:col-6">
+              <label htmlFor="dob">DOB</label>
+              <Calendar
+                id="dob"
+                value={form.dob ? new Date(form.dob) : undefined}
+                onChange={(e) =>
+                  handleChange(
+                    'dob',
+                    (e.value as Date | null)?.toISOString().slice(0, 10) || ''
+                  )
+                }
+                dateFormat="yy-mm-dd"
+                showIcon
+              />
+            </div>
+            <div className="field col-12">
+              <label htmlFor="family_members">Family Members</label>
+              <InputTextarea
+                id="family_members"
+                rows={2}
+                value={form.family_members || ''}
+                onChange={(e) => handleChange('family_members', e.target.value)}
+              />
+            </div>
+            <div className="field col-12 md:col-6">
+              <label htmlFor="emergency_name">Emergency Name</label>
+              <InputText
+                id="emergency_name"
+                value={form.emergency_name || ''}
+                onChange={(e) => handleChange('emergency_name', e.target.value)}
+              />
+            </div>
+            <div className="field col-12 md:col-6">
+              <label htmlFor="emergency_number">Emergency Number</label>
+              <InputText
+                id="emergency_number"
+                value={form.emergency_number || ''}
+                onChange={(e) => handleChange('emergency_number', e.target.value)}
+              />
+            </div>
+            <div className="field col-12">
+              <label htmlFor="notes">Notes</label>
+              <InputTextarea
+                id="notes"
+                rows={3}
+                value={form.notes || ''}
+                onChange={(e) => handleChange('notes', e.target.value)}
+              />
+            </div>
+            <div className="col-12 flex justify-content-end gap-2 mt-3">
+              <Button
+                label="Save"
+                icon="pi pi-check"
+                onClick={save}
+                disabled={saving}
+                aria-label="Save member"
+              />
+              <Button
+                label="Cancel"
+                icon="pi pi-times"
+                className="p-button-outlined"
+                onClick={onCancel}
+                aria-label="Cancel edit"
+              />
+            </div>
+          </div>
+        ) : (
+          <div className="grid">
+            <div className="col-12 md:col-6">
+              <strong>Membership ID:</strong> {member.membership_id}
+            </div>
+            <div className="col-12 md:col-6">
+              <strong>First Name:</strong> {member.first_name}
+            </div>
+            <div className="col-12 md:col-6">
+              <strong>Last Name:</strong> {member.last_name}
+            </div>
+            <div className="col-12 md:col-6">
+              <strong>NIC:</strong> {member.nic}
+            </div>
+            <div className="col-12 md:col-6">
+              <strong>Phone:</strong> {member.phone}
+            </div>
+            <div className="col-12 md:col-6">
+              <strong>Email:</strong> {member.email || '-'}
+            </div>
+            <div className="col-12">
+              <strong>Address:</strong> {member.address}
+            </div>
+            <div className="col-12 md:col-6">
+              <strong>Join Date:</strong> {formatDate(member.join_date)}
+            </div>
+            <div className="col-12 md:col-6">
+              <strong>Status:</strong> {member.status}
+            </div>
+            <div className="col-12 md:col-6">
+              <strong>Occupation:</strong> {member.occupation}
+            </div>
+            <div className="col-12 md:col-6">
+              <strong>Gender:</strong> {member.gender}
+            </div>
+            <div className="col-12 md:col-6">
+              <strong>DOB:</strong> {formatDate(member.dob)}
+            </div>
+            <div className="col-12">
+              <strong>Family Members:</strong> {member.family_members}
+            </div>
+            <div className="col-12 md:col-6">
+              <strong>Emergency Name:</strong> {member.emergency_name}
+            </div>
+            <div className="col-12 md:col-6">
+              <strong>Emergency Number:</strong> {member.emergency_number}
+            </div>
+            <div className="col-12">
+              <strong>Notes:</strong> {member.notes || '-'}
+            </div>
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- remove view dialog and make membership IDs link to member bio page
- add editable bio page with form validation, save, and delete actions using PrimeReact

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

## How to Test
1. Start backend and `npm run dev`.
2. Create a member then navigate to `/apps/user-management/list`.
3. Click **Bio** or a Membership ID to open the profile.
4. Click **Edit**, change a field, and **Save**.
5. Click **Delete** and confirm to return to the list.


------
https://chatgpt.com/codex/tasks/task_e_68a3694289808330bdbd5428c992eccf